### PR TITLE
fix: default database url for backend

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -3,8 +3,14 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 import os
 
-SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL")
+# Fallback to the default database that ships with the docker-compose setup
+DEFAULT_DATABASE_URL = (
+    "mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog"
+)
+
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL") or DEFAULT_DATABASE_URL
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+


### PR DESCRIPTION
## Summary
- avoid SQLAlchemy parse errors by defaulting to the local MariaDB URL when `DATABASE_URL` is unset

## Testing
- `python -m py_compile backend/database.py && echo py_compile_success`


------
https://chatgpt.com/codex/tasks/task_e_68a87a6ab5a0832a8a303e814e265240