### PR TITLE
Handle invalid DATABASE_URL gracefully

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,6 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.exc import ArgumentError
 import os
 
 # Fallback to the default database that ships with the docker-compose setup
@@ -8,7 +10,20 @@ DEFAULT_DATABASE_URL = (
     "mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog"
 )
 
-SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL") or DEFAULT_DATABASE_URL
+# Validate the DATABASE_URL environment variable, falling back to the default if
+# it is missing or malformed.  This avoids crashes when docker-compose provides
+# an empty or otherwise unparsable value.
+raw_database_url = os.getenv("DATABASE_URL")
+if raw_database_url:
+    try:
+        # ``make_url`` raises ``ArgumentError`` if the value cannot be parsed
+        # as a valid SQLAlchemy URL.
+        make_url(raw_database_url)
+        SQLALCHEMY_DATABASE_URL = raw_database_url
+    except ArgumentError:
+        SQLALCHEMY_DATABASE_URL = DEFAULT_DATABASE_URL
+else:
+    SQLALCHEMY_DATABASE_URL = DEFAULT_DATABASE_URL
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- validate `DATABASE_URL` and fall back to default MySQL URL when invalid

## Testing
- `python -m py_compile backend/database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac33fbdb10832a9c5c36c2a932b3ae