### PR TITLE
Load .env.local and fallback BASE_URI to prevent Fuseki Bad URI errors

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,11 @@
+import os
+from dotenv import load_dotenv
+
+# Load local environment variables if present
+load_dotenv('.env.local')
+
+DEFAULT_BASE_URI = "https://semantic-data-catalog.com"
+
+def get_base_uri() -> str:
+    """Return BASE_URI from environment or a default value."""
+    return os.getenv("BASE_URI") or DEFAULT_BASE_URI

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 import requests
-import os
 from requests.auth import HTTPBasicAuth
+from config import get_base_uri
 from fastapi import FastAPI, Depends, File, UploadFile, Form, HTTPException
 from fastapi.responses import JSONResponse, Response
 from database import engine, Base
@@ -98,7 +98,7 @@ def create_dataset_entry(
 
     try:
         ttl_data = generate_dcat_dataset_ttl(dataset_data.model_dump())
-        BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+        BASE_URI = get_base_uri()
         dataset_uri = f"{BASE_URI}/id/{identifier}"
         insert_dataset_rdf(ttl_data.encode("utf-8"), graph_uri=dataset_uri)
         append_to_catalog_graph(dataset_uri)
@@ -148,7 +148,7 @@ def update_dataset_entry(
 
     updated = update_dataset(db, identifier, dataset_data)
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     dataset_uri = f"{BASE_URI}/id/{identifier}"
     try:
         ttl_data = generate_dcat_dataset_ttl(dataset_data.model_dump())
@@ -163,7 +163,7 @@ def update_dataset_entry(
 def delete_dataset_entry(identifier: str, db: Session = Depends(get_db)):
     deleted = delete_dataset(db, identifier)
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     dataset_uri = f"{BASE_URI}/id/{identifier}"
 
     try:

--- a/backend/triplestore.py
+++ b/backend/triplestore.py
@@ -1,6 +1,6 @@
 import requests
-import os
 from requests.auth import HTTPBasicAuth
+from config import get_base_uri
 from datetime import datetime
 
 FUSEKI_URL = "http://fuseki:3030/semantic_data_catalog/data"
@@ -10,7 +10,7 @@ def generate_dcat_dataset_ttl(dataset: dict) -> str:
     issued = dataset["issued"].isoformat() if isinstance(dataset["issued"], datetime) else dataset["issued"]
     modified = dataset["modified"].isoformat() if isinstance(dataset["modified"], datetime) else dataset["modified"]
     identifier = dataset["identifier"]
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     dataset_uri = f"{BASE_URI}/id/{identifier}"
     distribution_uri = f"{dataset_uri}/distribution"
     publisher_uri = f"{dataset_uri}/publisher"
@@ -68,7 +68,7 @@ def insert_dataset_rdf(ttl_data: bytes, graph_uri: str):
         raise Exception(f"Insert failed: {response.status_code} – {response.text}")
     
 def append_to_catalog_graph(dataset_uri: str):
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     catalog_uri = f"{BASE_URI}/catalog"
     graph_uri = catalog_uri
 
@@ -93,7 +93,7 @@ def append_to_catalog_graph(dataset_uri: str):
         raise Exception(f"Failed to update catalog graph: {res.status_code} – {res.text}")
     
 def remove_from_catalog_graph(dataset_uri: str):
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     catalog_uri = f"{BASE_URI}/catalog"
 
     delete_query = f"""

--- a/backend/triplestore_migration.py
+++ b/backend/triplestore_migration.py
@@ -2,12 +2,12 @@ import mysql.connector
 from rdflib import Graph, Namespace, URIRef, Literal
 from rdflib.namespace import RDF, DCTERMS, FOAF, XSD
 import requests
-import os
 from requests.auth import HTTPBasicAuth
+from config import get_base_uri
 
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
-BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+BASE_URI = get_base_uri()
 EX = Namespace(f"{BASE_URI}/id/")
 
 FUSEKI_DATA_URL = "http://fuseki:3030/semantic_data_catalog/data"
@@ -55,7 +55,7 @@ def migrate_to_fuseki():
     catalog_graph.bind("foaf", FOAF)
     catalog_graph.bind("vcard", VCARD)
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     catalog_uri = URIRef(f"{BASE_URI}/catalog")
 
     cursor.execute("SELECT * FROM catalogs")
@@ -79,7 +79,7 @@ def migrate_to_fuseki():
             dataset_graph.bind("foaf", FOAF)
             dataset_graph.bind("vcard", VCARD)
 
-            BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+            BASE_URI = get_base_uri()
             dataset_uri = URIRef(f"{BASE_URI}/id/{ds['identifier']}")
             publisher_uri = URIRef(f"{dataset_uri}/publisher")
             distribution_uri = URIRef(f"{dataset_uri}/distribution")
@@ -130,7 +130,7 @@ def migrate_to_fuseki():
 
             catalog_graph.add((catalog_uri, DCAT.dataset, dataset_uri))
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = get_base_uri()
     upload_named_graph(catalog_graph, graph_uri=f"{BASE_URI}/catalog")
 
     print("Migration completed.")


### PR DESCRIPTION
## Summary
- load `.env.local` and provide a `get_base_uri` helper with default URL
- use `get_base_uri` across backend modules so missing/empty BASE_URI no longer creates relative graph URIs

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac384b6f10832a8103ce9de7596af5