### PR TITLE
fix: proxy api requests without caddy

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@inrupt/solid-client-authn-browser": "^2.3.0",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "axios": "^1.7.7",
+        "http-proxy-middleware": "^2.0.9",
         "n3": "^1.23.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -9300,9 +9301,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@inrupt/solid-client-authn-browser": "^2.3.0",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "axios": "^1.7.7",
+    "http-proxy-middleware": "^2.0.9",
     "n3": "^1.23.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
@@ -24,6 +25,5 @@
     ">0.2%",
     "not dead",
     "not op_mini all"
-  ],
-  "proxy": "http://backend:8000"
+  ]
 }

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,0 +1,12 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: 'http://backend:8000',
+      changeOrigin: true,
+      pathRewrite: {'^/api': ''},
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- add http-proxy-middleware and proxy setup to strip `/api` prefix before forwarding to backend
- remove deprecated package.json proxy field

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ac44ea3468832a8ab12306b50e46a1