### PR TITLE
feat: support subpath deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ REACT_APP_FOOTER_LOGOS=/assets/images/Logo_GesundesTal.png,/assets/images/Icon_G
 REACT_APP_VERSION=0.5.0
 ```
 
+The frontend is configured to run under the `/semantic-data-catalog` base path. Adjust the `PUBLIC_URL` value in `package.json` or set it in your environment if you deploy the UI elsewhere.
+
 ---
 
 ### Fuseki (`fuseki` service)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "semantic-data-catalog-frontend",
   "version": "0.0.1",
   "private": true,
+  "homepage": "/semantic-data-catalog",
   "dependencies": {
     "@inrupt/solid-client": "^1.30.2",
     "@inrupt/solid-client-authn-browser": "^2.3.0",
@@ -15,9 +16,9 @@
     "vis-network": "^9.1.9"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "start-watch": "WATCHPACK_POLLING=true react-scripts start",
-    "build": "react-scripts build",
+    "start": "PUBLIC_URL=/semantic-data-catalog react-scripts start",
+    "start-watch": "PUBLIC_URL=/semantic-data-catalog WATCHPACK_POLLING=true react-scripts start",
+    "build": "PUBLIC_URL=/semantic-data-catalog react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css">
-    <link rel="icon" href="/assets/images/Logo_TMDT.png" />
+    <link rel="stylesheet" href="%PUBLIC_URL%/styles.css">
+    <link rel="icon" href="%PUBLIC_URL%/assets/images/Logo_TMDT.png" />
     <title>Semantic Data Catalog</title>
 </head>
 <body>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -143,16 +143,16 @@ const App = () => {
 
                 {showOntologyDropdown && (
                   <div className="dropdown-menu show dropdown-visible">
-                    <a className="dropdown-item" href="/assets/ontologies/dcat3.ttl" download>
+                    <a className="dropdown-item" href={process.env.PUBLIC_URL + '/assets/ontologies/dcat3.ttl'} download>
                       DCAT3 – Data Catalog Vocabulary 3.0
                     </a>
-                    <a className="dropdown-item" href="/assets/ontologies/sdo.ttl" download>
+                    <a className="dropdown-item" href={process.env.PUBLIC_URL + '/assets/ontologies/sdo.ttl'} download>
                       SDO – Schema.org Core Terms
                     </a>
-                    <a className="dropdown-item" href="/assets/ontologies/sosa.ttl" download>
+                    <a className="dropdown-item" href={process.env.PUBLIC_URL + '/assets/ontologies/sosa.ttl'} download>
                       SOSA – Sensor, Observation, Sample, and Actuator
                     </a>
-                    <a className="dropdown-item" href="/assets/ontologies/vcslam.ttl" download>
+                    <a className="dropdown-item" href={process.env.PUBLIC_URL + '/assets/ontologies/vcslam.ttl'} download>
                       VCSLAM – Vocabulary for Contextualized Semantic Linking
                     </a>
                   </div>

--- a/frontend/src/components/FooterBar.js
+++ b/frontend/src/components/FooterBar.js
@@ -3,14 +3,20 @@ import React from 'react';
 const FooterBar = () => {
   const rawLogos = process.env.REACT_APP_FOOTER_LOGOS;
   const logos = rawLogos
-  ? rawLogos.split(",").map(l => l.trim()).filter(Boolean)
+  ? rawLogos
+      .split(",")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((src) =>
+        src.startsWith("http") ? src : `${process.env.PUBLIC_URL}${src}`
+      )
   : [];
 
   return (
     <footer className="footer-bar">
       <div className="footer-logo-group">
-        <img src="/assets/images/Logo_BUW.png" alt="Logo BUW" className="logo-small" />
-        <img src="/assets/images/Logo_TMDT.png" alt="Logo TMDT" className="logo-medium" />
+        <img src={process.env.PUBLIC_URL + '/assets/images/Logo_BUW.png'} alt="Logo BUW" className="logo-small" />
+        <img src={process.env.PUBLIC_URL + '/assets/images/Logo_TMDT.png'} alt="Logo TMDT" className="logo-medium" />
         {logos.map((src, index) => (
           <img key={index} src={src} alt={`Logo ${index}`} className="logo-small" />
         ))}

--- a/frontend/src/components/LoginIssuerModal.js
+++ b/frontend/src/components/LoginIssuerModal.js
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 const LoginIssuerModal = ({ onClose, onLogin }) => {
   const [customIssuer, setCustomIssuer] = useState('');
 
-  const solidLogo = "/assets/images/solid.svg";
+  const solidLogo = process.env.PUBLIC_URL + "/assets/images/solid.svg";
 
   return (
     <div className="modal show modal-show d-block" tabIndex="-1" role="dialog">


### PR DESCRIPTION
## Summary
- configure React frontend to run under `/semantic-data-catalog`
- reference static assets via `PUBLIC_URL`
- document base path configuration

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc4c3b630832a8ba9abc0222d58bd