### PR TITLE
fix: adjust header link for subpath

### DIFF
--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -105,7 +105,7 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
     <div className="header-bar">
       <div className="d-flex align-items-center">
         <div className="header-title">
-          <a href="/">
+          <a href={process.env.PUBLIC_URL + '/'}>
             Semantic <span className="highlight">Data</span> Catalog
           </a>
         </div>


### PR DESCRIPTION
## Summary
- ensure header link respects PUBLIC_URL for subpath navigation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ae940f3d84832a8f84c56a03f2d5a8