### PR TITLE
Allow runtime configuration of Solid redirect URL

### DIFF
--- a/frontend/public/env.js
+++ b/frontend/public/env.js
@@ -1,0 +1,3 @@
+window._env_ = {
+  REACT_APP_REDIRECT_URL: ""
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="%PUBLIC_URL%/styles.css">
     <link rel="icon" href="%PUBLIC_URL%/assets/images/Logo_TMDT.png" />
     <title>Semantic Data Catalog</title>
+    <script src="%PUBLIC_URL%/env.js"></script>
 </head>
 <body>
     <!-- Root element for React -->

--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -26,10 +26,20 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
 
   const session = getDefaultSession();
 
+  const getRedirectUrl = () => {
+    if (window._env_ && window._env_.REACT_APP_REDIRECT_URL) {
+      return window._env_.REACT_APP_REDIRECT_URL;
+    }
+    if (process.env.REACT_APP_REDIRECT_URL) {
+      return process.env.REACT_APP_REDIRECT_URL;
+    }
+    return `${window.location.origin}${process.env.PUBLIC_URL || ''}/`;
+  };
+
   const loginWithIssuer = (issuer) => {
     login({
       oidcIssuer: issuer,
-      redirectUrl: process.env.REACT_APP_REDIRECT_URL,
+      redirectUrl: getRedirectUrl(),
       clientName: "Semantic Data Catalog",
     });
   };


### PR DESCRIPTION
## Summary
- load new `env.js` for runtime configuration
- compute Solid login redirect from runtime env or current location

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ae94947610832aabda82ef23986895