### PR TITLE
Avoid redundant Solid re-login when session already authenticated

### DIFF
--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -89,9 +89,10 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
         const wasLoggedIn = localStorage.getItem("solid-was-logged-in") === "true";
         if (wasLoggedIn) {
           const lastIssuer = localStorage.getItem("solid-oidc-issuer") || process.env.REACT_APP_OIDC_ISSUER;
-          loginWithIssuer(lastIssuer);
-        }
-        else {
+          if (!session.info.isLoggedIn) {
+            loginWithIssuer(lastIssuer);
+          }
+        } else {
           if (onLoginStatusChange) onLoginStatusChange(false);
         }
       }


### PR DESCRIPTION
## Summary
- Skip calling `loginWithIssuer` if the session is already logged in to prevent unnecessary redirects.

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ae96d35920832abe259ed9372d0318