### PR TITLE
Fix frontend proxy to retain /api prefix

### DIFF
--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -5,8 +5,7 @@ module.exports = function(app) {
     '/api',
     createProxyMiddleware({
       target: 'http://backend:8000',
-      changeOrigin: true,
-      pathRewrite: {'^/api': ''},
+      changeOrigin: true
     })
   );
 };


### PR DESCRIPTION
## Summary
- preserve `/api` path prefix when proxying requests to backend

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1ab0b0284832ab2f8257d1d707e43