### PR TITLE
fix(frontend): correct proxy target for backend

### DIFF
--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,11 +1,16 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function(app) {
+// Use an environment variable for the backend URL if provided, otherwise
+// fall back to the Docker service name. This ensures that the proxy works
+// both in local development and within the docker-compose setup.
+const target = process.env.BACKEND_URL || 'http://semantic-data-catalog-backend:8000';
+
+module.exports = function (app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'http://backend:8000',
-      changeOrigin: true
-    })
+      target,
+      changeOrigin: true,
+    }),
   );
 };


### PR DESCRIPTION
## Summary
- fix frontend proxy configuration to point to the correct backend service
- allow overriding proxy target via `BACKEND_URL` env variable

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5959b62fc832aadf61ba5e6efc92e