### PR TITLE
Initialize Solid authentication in main app component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import {
+  handleIncomingRedirect,
+  getDefaultSession,
+  login,
+} from '@inrupt/solid-client-authn-browser';
 import SearchBar from './components/SearchBar';
 import DatasetTable from './components/DatasetTable';
 import DatasetAddModal from './components/DatasetAddModal';
@@ -28,6 +33,26 @@ const App = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const pageSize = 10;
+
+  useEffect(() => {
+    const initAuth = async () => {
+      await handleIncomingRedirect({ restorePreviousSession: true });
+      const session = getDefaultSession();
+      if (!session.info.isLoggedIn) {
+        setIsLoggedIn(false);
+        setWebId(null);
+        login({
+          oidcIssuer: 'https://tmdt-solid-community-server.de',
+          redirectUrl: window.location.href,
+          clientName: 'Semantic Data Catalog',
+        });
+      } else {
+        setIsLoggedIn(true);
+        setWebId(session.info.webId);
+      }
+    };
+    initAuth();
+  }, []);
 
   const fetchTotalPages = async () => {
     try {


### PR DESCRIPTION
## Summary
- establish Solid session handling via `handleIncomingRedirect` on app mount
- auto-login with configured Solid issuer when no session exists
- expose session login status and WebID through component state

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b5b4b9a05c832aae76d222d74579db