### PR TITLE
Use dedicated Solid session

### DIFF
--- a/frontend/src/components/DatasetAddModal.js
+++ b/frontend/src/components/DatasetAddModal.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
+import { session } from "../solidSession";
 import {
   getSolidDataset,
   getContainedResourceUrlAll,
@@ -31,7 +31,7 @@ const DatasetAddModal = ({ onClose, fetchDatasets, fetchTotalPages }) => {
   const [modelPodFiles, setModelPodFiles] = useState([]);
   const [loading, setLoading] = useState(false);
 
-  const session = getDefaultSession();
+  // Use shared Solid session from solidSession.js
   const [solidUserName, setSolidUserName] = useState('');
   const [webId, setWebId] = useState('');
 

--- a/frontend/src/components/DatasetEditModal.js
+++ b/frontend/src/components/DatasetEditModal.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
+import { session } from "../solidSession";
 import {
   getSolidDataset,
   getContainedResourceUrlAll,
@@ -12,7 +12,7 @@ import {
 import { FOAF, VCARD } from "@inrupt/vocab-common-rdf";
 
 const DatasetEditModal = ({ dataset, onClose, fetchDatasets }) => {
-  const session = getDefaultSession();
+  // Shared Solid session instance
 
   const [editedDataset, setEditedDataset] = useState(null);
   const [datasetPodFiles, setDatasetPodFiles] = useState([]);

--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -1,10 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  getDefaultSession,
-  handleIncomingRedirect,
-  login,
-  logout
-} from "@inrupt/solid-client-authn-browser";
+import { session } from "../solidSession";
 import {
   getSolidDataset,
   getThing,
@@ -24,7 +19,8 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
     photo: ''
   });
 
-  const session = getDefaultSession();
+  // Use a dedicated session instance for this app
+  // (see ../solidSession.js)
 
   const getRedirectUrl = () => {
     if (window._env_ && window._env_.REACT_APP_REDIRECT_URL) {
@@ -37,7 +33,7 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
   };
 
   const loginWithIssuer = (issuer) => {
-    login({
+    session.login({
       oidcIssuer: issuer,
       redirectUrl: getRedirectUrl(),
       clientName: "Semantic Data Catalog",
@@ -105,7 +101,7 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
   };
 
   useEffect(() => {
-    handleIncomingRedirect({ restorePreviousSession: true }).then(() => {
+    session.handleIncomingRedirect(window.location.href, { restorePreviousSession: true }).then(() => {
       if (session.info.isLoggedIn && session.info.webId) {
         localStorage.setItem("solid-was-logged-in", "true");
         fetchPodUserInfo(session.info.webId);
@@ -132,7 +128,7 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
       photo: ''
     });
     if (onLoginStatusChange) onLoginStatusChange(false);
-    logout({ logoutRedirectUrl: window.location.href });
+    session.logout({ logoutRedirectUrl: window.location.href });
     window.location.reload();
   };
 

--- a/frontend/src/solidSession.js
+++ b/frontend/src/solidSession.js
@@ -1,0 +1,3 @@
+import { Session } from "@inrupt/solid-client-authn-browser";
+
+export const session = new Session({ sessionId: 'semantic-data-catalog' });


### PR DESCRIPTION
## Summary
- Replace default Solid auth helper calls with a shared `Session` identified as `semantic-data-catalog`.
- Update dataset add/edit modals to use the same session instance for Solid fetches.
- Introduce `solidSession.js` to manage the custom session.

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b69a99a994832aab83ccb767cbf535