### PR TITLE
feat: grant semantic model access with dataset

### DIFF
--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -87,7 +87,10 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId }) => {
       };
 
       const datasetAccess = await hasAclAccess(dataset.access_url_dataset);
-      const modelAccess = await hasAclAccess(dataset.access_url_semantic_model);
+      let modelAccess = datasetAccess;
+      if (!modelAccess) {
+        modelAccess = await hasAclAccess(dataset.access_url_semantic_model);
+      }
       setCanAccessDataset(datasetAccess);
       setCanAccessModel(modelAccess);
     };


### PR DESCRIPTION
## Summary
- treat semantic model as accessible whenever the dataset file ACL grants access

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3b3362c832ab12f266c694816b2