### PR TITLE
Rename Fuseki Triple Store link to Semantic Search

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -138,8 +138,8 @@ const App = () => {
                 rel="noopener noreferrer"
                 className="btn btn-light mr-2"
               >
-                <i className="fa-solid fa-database mr-2"></i>
-                Fuseki Triple Store
+                <i className="fa-solid fa-magnifying-glass mr-2"></i>
+                Semantic Search
               </a>
               <div className="position-relative mr-2">
                 <button


### PR DESCRIPTION
## Summary
- update frontend link label from "Fuseki Triple Store" to "Semantic Search"
- swap database icon for magnifying glass using Font Awesome

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b7f64c90a4832a9ca62648d07d7e06