### PR TITLE
feat: increase upload size limit

### DIFF
--- a/backend/alembic/versions/11915fdc90a2_initial_migration.py
+++ b/backend/alembic/versions/11915fdc90a2_initial_migration.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
 
 
 # revision identifiers, used by Alembic.
@@ -41,7 +42,7 @@ def upgrade() -> None:
     sa.Column('file_format', sa.String(length=50), nullable=True),
     sa.Column('is_public', sa.Boolean(), nullable=False),
     sa.Column('theme', sa.String(length=255), nullable=True),
-    sa.Column('semantic_model_file', sa.LargeBinary(), nullable=True),
+    sa.Column('semantic_model_file', mysql.LONGBLOB(), nullable=True),
     sa.Column('semantic_model_file_name', sa.String(length=255), nullable=True),
     sa.Column('catalog_id', sa.Integer(), nullable=True),
     sa.Column('webid', sa.String(length=255), nullable=True),

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey, LargeBinary
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey
+from sqlalchemy.dialects.mysql import LONGBLOB
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
@@ -20,7 +21,7 @@ class Dataset(Base):
     file_format = Column(String(50), nullable=True)
     is_public = Column(Boolean, default=True, nullable=False)
     theme = Column(String(255), nullable=True)
-    semantic_model_file = Column(LargeBinary, nullable=True)
+    semantic_model_file = Column(LONGBLOB, nullable=True)
     semantic_model_file_name = Column(String(255), nullable=True)
     catalog_id = Column(Integer, ForeignKey('catalogs.id'), nullable=True)
     webid = Column(String(255), nullable=True)


### PR DESCRIPTION
## Summary
- allow large uploads by using MySQL LONGBLOB for semantic model files

## Testing
- `python -m py_compile backend/models.py backend/alembic/versions/11915fdc90a2_initial_migration.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8334512e0832a82dc0f9c7b3dbe67