### PR TITLE
feat: restore solid session and use authenticated fetch

### DIFF
--- a/frontend/src/components/DatasetEditModal.js
+++ b/frontend/src/components/DatasetEditModal.js
@@ -107,9 +107,12 @@ const DatasetEditModal = ({ dataset, onClose, fetchDatasets }) => {
       const formData = new FormData();
   
       if (editedDataset.access_url_semantic_model) {
-        const response = await fetch(editedDataset.access_url_semantic_model);
+        // Use the authenticated Solid session to fetch files from the pod so
+        // that restricted resources can be accessed.
+        const response = await session.fetch(editedDataset.access_url_semantic_model);
         const blob = await response.blob();
-        const filename = editedDataset.access_url_semantic_model.split('/').pop() || "model.ttl";
+        const filename =
+          editedDataset.access_url_semantic_model.split('/').pop() || "model.ttl";
         const file = new File([blob], filename, { type: "text/turtle" });
         formData.append("semantic_model_file", file);
       }

--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -11,7 +11,6 @@ import LoginIssuerModal from './LoginIssuerModal';
 
 const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab }) => {
   const [showLoginModal, setShowLoginModal] = useState(false);
-  const [customIssuer, setCustomIssuer] = useState('');
   const [userInfo, setUserInfo] = useState({
     loggedIn: false,
     name: '',
@@ -101,22 +100,19 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
   };
 
   useEffect(() => {
-    session.handleIncomingRedirect(window.location.href, { restorePreviousSession: true }).then(() => {
-      if (session.info.isLoggedIn && session.info.webId) {
-        localStorage.setItem("solid-was-logged-in", "true");
-        fetchPodUserInfo(session.info.webId);
+    if (session.info.isLoggedIn && session.info.webId) {
+      localStorage.setItem("solid-was-logged-in", "true");
+      fetchPodUserInfo(session.info.webId);
+    } else {
+      const wasLoggedIn = localStorage.getItem("solid-was-logged-in") === "true";
+      if (wasLoggedIn) {
+        const lastIssuer =
+          localStorage.getItem("solid-oidc-issuer") || process.env.REACT_APP_OIDC_ISSUER;
+        loginWithIssuer(lastIssuer);
       } else {
-        const wasLoggedIn = localStorage.getItem("solid-was-logged-in") === "true";
-        if (wasLoggedIn) {
-          const lastIssuer = localStorage.getItem("solid-oidc-issuer") || process.env.REACT_APP_OIDC_ISSUER;
-          if (!session.info.isLoggedIn) {
-            loginWithIssuer(lastIssuer);
-          }
-        } else {
-          if (onLoginStatusChange) onLoginStatusChange(false);
-        }
+        if (onLoginStatusChange) onLoginStatusChange(false);
       }
-    });
+    }
   }, []);
 
   const handleLogout = () => {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { restoreSession } from './solidSession';
 
 const rootElement = document.getElementById('root');
 
-if (rootElement) {
+// Ensure the Solid session is restored before rendering the application so
+// that components relying on authentication have the correct state on load.
+restoreSession().finally(() => {
+  if (rootElement) {
     const root = ReactDOM.createRoot(rootElement);
     root.render(<App />);
-} else {
+  } else {
     console.error("Root container not found");
-}
+  }
+});

--- a/frontend/src/solidSession.js
+++ b/frontend/src/solidSession.js
@@ -1,3 +1,16 @@
 import { Session } from "@inrupt/solid-client-authn-browser";
 
+// Shared Solid session with a fixed ID so that login information can be
+// restored automatically after a page refresh.
 export const session = new Session({ sessionId: 'semantic-data-catalog' });
+
+// Restore a previous Solid session, if any, and handle redirects coming back
+// from the identity provider. This should be awaited before rendering the app
+// so that `session.info` is up to date.
+export async function restoreSession() {
+  if (typeof window === "undefined") return;
+  await session.handleIncomingRedirect(window.location.href, {
+    restorePreviousSession: true,
+  });
+}
+


### PR DESCRIPTION
## Summary
- restore previous Solid session before rendering the app
- auto-retry login and fetch profile using stored session
- fetch semantic model files with the authenticated Solid session

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9671ecf5c832a89706d92e3b93626