### PR TITLE
Persist Solid session across refresh

### DIFF
--- a/frontend/src/solidSession.js
+++ b/frontend/src/solidSession.js
@@ -1,8 +1,12 @@
 import { Session } from "@inrupt/solid-client-authn-browser";
 
 // Shared Solid session with a fixed ID so that login information can be
-// restored automatically after a page refresh.
-export const session = new Session({ sessionId: 'semantic-data-catalog' });
+// restored automatically after a page refresh. Persist session state in
+// `localStorage` so that a full page reload keeps the user logged in.
+export const session = new Session({
+  sessionId: 'semantic-data-catalog',
+  storage: typeof window !== "undefined" ? localStorage : undefined,
+});
 
 // Restore a previous Solid session, if any, and handle redirects coming back
 // from the identity provider. This should be awaited before rendering the app


### PR DESCRIPTION
## Summary
- Persist Solid session in `localStorage` so users stay logged in after page reload

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b978801f44832ab8ac9008bbced2b4