### PR TITLE
Use default Solid session for persistence

### DIFF
--- a/frontend/src/solidSession.js
+++ b/frontend/src/solidSession.js
@@ -1,8 +1,9 @@
-import { Session } from "@inrupt/solid-client-authn-browser";
+import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
 
-// Shared Solid session with a fixed ID so that login information can be
-// restored automatically after a page refresh.
-export const session = new Session({ sessionId: 'semantic-data-catalog' });
+// Use the default Solid session instance, which automatically persists its
+// state to `localStorage`. This keeps the user logged in across full page
+// reloads without needing a manually managed session ID.
+export const session = getDefaultSession();
 
 // Restore a previous Solid session, if any, and handle redirects coming back
 // from the identity provider. This should be awaited before rendering the app


### PR DESCRIPTION
## Summary
- switch to the Solid client's default session so login data is stored in localStorage and reused

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b978801f44832ab8ac9008bbced2b4