### PR TITLE
fix solid session and base path for reverse proxy

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "n3": "^1.23.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "react-router-dom": "^6.22.2",
         "react-scripts": "^5.0.1",
         "vis-network": "^9.1.9"
       }
@@ -3312,6 +3313,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -14318,6 +14328,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-data-catalog-frontend",
   "version": "0.0.1",
   "private": true,
-  "homepage": "/semantic-data-catalog/",
+  "homepage": "/semantic-data-catalog",
   "dependencies": {
     "@inrupt/solid-client": "^1.30.2",
     "@inrupt/solid-client-authn-browser": "^2.3.0",
@@ -12,13 +12,14 @@
     "n3": "^1.23.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "react-router-dom": "^6.22.2",
     "react-scripts": "^5.0.1",
     "vis-network": "^9.1.9"
   },
   "scripts": {
-    "start": "PUBLIC_URL=/semantic-data-catalog/ react-scripts start",
-    "start-watch": "PUBLIC_URL=/semantic-data-catalog/ WATCHPACK_POLLING=true react-scripts start",
-    "build": "PUBLIC_URL=/semantic-data-catalog/ react-scripts build",
+    "start": "PUBLIC_URL=/semantic-data-catalog react-scripts start",
+    "start-watch": "PUBLIC_URL=/semantic-data-catalog WATCHPACK_POLLING=true react-scripts start",
+    "build": "PUBLIC_URL=/semantic-data-catalog react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -21,21 +21,11 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
   // Use a dedicated session instance for this app
   // (see ../solidSession.js)
 
-  const getRedirectUrl = () => {
-    if (window._env_ && window._env_.REACT_APP_REDIRECT_URL) {
-      return window._env_.REACT_APP_REDIRECT_URL;
-    }
-    if (process.env.REACT_APP_REDIRECT_URL) {
-      return process.env.REACT_APP_REDIRECT_URL;
-    }
-    return `${window.location.origin}${process.env.PUBLIC_URL || ''}/`;
-  };
-
   const loginWithIssuer = (issuer) => {
     session.login({
       oidcIssuer: issuer,
-      redirectUrl: getRedirectUrl(),
-      clientName: "Solid Dataspace",
+      redirectUrl: window.location.href,
+      clientName: "Semantic Data Catalog",
     });
   };
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { restoreSession } from './solidSession';
 
@@ -10,7 +11,11 @@ const rootElement = document.getElementById('root');
 restoreSession().finally(() => {
   if (rootElement) {
     const root = ReactDOM.createRoot(rootElement);
-    root.render(<App />);
+    root.render(
+      <BrowserRouter basename={process.env.PUBLIC_URL}>
+        <App />
+      </BrowserRouter>
+    );
   } else {
     console.error("Root container not found");
   }

--- a/frontend/src/solidSession.js
+++ b/frontend/src/solidSession.js
@@ -1,9 +1,12 @@
-import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
+import { Session } from "@inrupt/solid-client-authn-browser";
 
-// Use the default Solid session instance, which automatically persists its
-// state to `localStorage`. This keeps the user logged in across full page
-// reloads without needing a manually managed session ID.
-export const session = getDefaultSession();
+// Create a dedicated Solid session for this app with its own session ID so
+// that multiple applications running on the same domain don't overwrite each
+// other's authentication state in localStorage.
+export const session = new Session({
+  clientName: "Semantic Data Catalog",
+  sessionId: "semantic-data-catalog",
+});
 
 // Restore a previous Solid session, if any, and handle redirects coming back
 // from the identity provider. This should be awaited before rendering the app


### PR DESCRIPTION
## Summary
- set `/semantic-data-catalog` as app base path and use BrowserRouter with basename
- restore previous Solid sessions and avoid collision by using unique session ID and client name
- always redirect back to current page after Solid login

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba89ac7ec8832a901a9ccd2dd887b9