### PR TITLE
Centralize environment configuration in docker-compose

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,0 @@
-BASE_URI=http://localhost/semantic-data-catalog/
-DATABASE_URL=mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog
-FRONTEND_REDIRECT=http://localhost/semantic-data-catalog/

--- a/README.md
+++ b/README.md
@@ -11,26 +11,16 @@ A FAIR-compliant **Semantic Data Catalog** designed for decentralized Solid-base
 ### Local Deployment
 
 ```bash
-docker-compose --env-file .env.local up -d --build
+docker-compose up -d --build
 ```
 
-This starts the full stack locally, including frontend, backend, Fuseki, and MariaDB. Make sure to create a `.env.local` file in the root with all required environment variables (see below).
+This starts the full stack locally, including frontend, backend, Fuseki, and MariaDB. All required environment variables are defined directly in the `docker-compose.yaml`.
 
 The frontend will be available at [http://localhost:5000](http://localhost:5000).
 
-### Production Deployment
-
-```bash
-docker-compose --env-file .env.production up -d --build
-```
-
-Use a dedicated `.env.production` file to provide production-specific environment variables.
-
----
-
 ## Environment Configuration
 
-You can customize the deployment by changing environment variables in your `.env.local` or `.env.production` file. Here's how key variables map to the `docker-compose.yaml`:
+You can customize the deployment by editing the environment variables directly in `docker-compose.yaml`. Here's how key variables map to the services:
 
 ### Database (`db` service)
 
@@ -52,8 +42,8 @@ The backend reads its configuration via:
 
 ```yaml
 environment:
-  - BASE_URI=${BASE_URI}
-  - DATABASE_URL=${DATABASE_URL}
+  - BASE_URI=http://localhost/
+  - DATABASE_URL=mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog
   - CATALOG_NAME=Semantic Data Catalog
   - CATALOG_DESCRIPTION=Demonstrator Instance
   - RESET_DB=true
@@ -69,12 +59,13 @@ environment:
 
 ### Frontend (`frontend` service)
 
-Set these in your `.env.local` to control Solid login and version display:
+The frontend uses the following environment variables:
 
-```env
-REACT_APP_OIDC_ISSUER=https://solidcommunity.net
-REACT_APP_REDIRECT_URL=http://localhost:5000
-REACT_APP_VERSION=0.5.0
+```yaml
+environment:
+  - REACT_APP_OIDC_ISSUER=https://solidcommunity.net
+  - REACT_APP_REDIRECT_URL=http://localhost:5000
+  - REACT_APP_VERSION=0.5.0
 ```
 
 The frontend is configured to run under the `/semantic-data-catalog` base path. Adjust the `PUBLIC_URL` value in `package.json` or set it in your environment if you deploy the UI elsewhere.

--- a/backend/database.py
+++ b/backend/database.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 import os
 
-SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL")
+SQLALCHEMY_DATABASE_URL = os.environ["DATABASE_URL"]
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -84,8 +84,8 @@ def create_dataset_entry(
         if parsed_url.scheme not in {"http", "https"}:
             raise HTTPException(status_code=400, detail="Invalid URL scheme for semantic model")
 
-        allowed_hosts_env = os.getenv("SEMANTIC_MODEL_HOST_ALLOWLIST", "")
-        allowed_hosts = [h.strip() for h in allowed_hosts_env.split(",") if h.strip()]
+        allowed_hosts_env = os.getenv("SEMANTIC_MODEL_HOST_ALLOWLIST")
+        allowed_hosts = [h.strip() for h in allowed_hosts_env.split(",") if h.strip()] if allowed_hosts_env else []
         if allowed_hosts and parsed_url.hostname not in allowed_hosts:
             raise HTTPException(status_code=400, detail="Host not allowed for semantic model")
 
@@ -133,7 +133,7 @@ def create_dataset_entry(
 
     try:
         ttl_data = generate_dcat_dataset_ttl(dataset_data.model_dump())
-        BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+        BASE_URI = os.environ["BASE_URI"]
         dataset_uri = f"{BASE_URI}/id/{identifier}"
         insert_dataset_rdf(ttl_data.encode("utf-8"), graph_uri=dataset_uri)
         append_to_catalog_graph(dataset_uri)
@@ -178,7 +178,7 @@ def update_dataset_entry(
 
     updated = update_dataset(db, identifier, dataset_data)
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     old_dataset_uri = f"{BASE_URI}/id/{identifier}"
     new_dataset_uri = f"{BASE_URI}/id/{updated.identifier}" if updated else old_dataset_uri
     try:
@@ -196,7 +196,7 @@ def update_dataset_entry(
 def delete_dataset_entry(identifier: str, db: Session = Depends(get_db)):
     deleted = delete_dataset(db, identifier)
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     dataset_uri = f"{BASE_URI}/id/{identifier}"
 
     try:

--- a/backend/populate.py
+++ b/backend/populate.py
@@ -249,19 +249,19 @@ def populate_db(db: Session):
 def main():
     ensure_fuseki_dataset_exists()
 
-    reset_env = os.getenv("RESET_DB", "false").lower() == "true"
-    populate_env = os.getenv("RUN_POPULATE", "false").lower() == "true"
+    reset_env = os.getenv("RESET_DB")
+    populate_env = os.getenv("RUN_POPULATE")
 
     db = SessionLocal()
     try:
-        if reset_env:
+        if reset_env and reset_env.lower() == "true":
             reset_database(db)
 
             reset_triplestore()
 
             create_catalog_entry(db)
 
-        if populate_env:
+        if populate_env and populate_env.lower() == "true":
             populate_db(db)
 
             migrate_to_fuseki()

--- a/backend/triplestore.py
+++ b/backend/triplestore.py
@@ -10,7 +10,7 @@ def generate_dcat_dataset_ttl(dataset: dict) -> str:
     issued = dataset["issued"].isoformat() if isinstance(dataset["issued"], datetime) else dataset["issued"]
     modified = dataset["modified"].isoformat() if isinstance(dataset["modified"], datetime) else dataset["modified"]
     identifier = dataset["identifier"]
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     dataset_uri = f"{BASE_URI}/id/{identifier}"
     distribution_uri = f"{dataset_uri}/distribution"
     publisher_uri = f"{dataset_uri}/publisher"
@@ -69,7 +69,7 @@ def insert_dataset_rdf(ttl_data: bytes, graph_uri: str):
         raise Exception(f"Insert failed: {response.status_code} – {response.text}")
     
 def append_to_catalog_graph(dataset_uri: str):
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     catalog_uri = f"{BASE_URI}/catalog"
     graph_uri = catalog_uri
 
@@ -94,7 +94,7 @@ def append_to_catalog_graph(dataset_uri: str):
         raise Exception(f"Failed to update catalog graph: {res.status_code} – {res.text}")
     
 def remove_from_catalog_graph(dataset_uri: str):
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     catalog_uri = f"{BASE_URI}/catalog"
 
     delete_query = f"""

--- a/backend/triplestore_migration.py
+++ b/backend/triplestore_migration.py
@@ -7,7 +7,7 @@ from requests.auth import HTTPBasicAuth
 
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
-BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+BASE_URI = os.environ["BASE_URI"]
 EX = Namespace(f"{BASE_URI}/id/")
 
 FUSEKI_DATA_URL = "http://fuseki:3030/semantic_data_catalog/data"
@@ -55,7 +55,7 @@ def migrate_to_fuseki():
     catalog_graph.bind("foaf", FOAF)
     catalog_graph.bind("vcard", VCARD)
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     catalog_uri = URIRef(f"{BASE_URI}/catalog")
 
     cursor.execute("SELECT * FROM catalogs")
@@ -79,7 +79,7 @@ def migrate_to_fuseki():
             dataset_graph.bind("foaf", FOAF)
             dataset_graph.bind("vcard", VCARD)
 
-            BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+            BASE_URI = os.environ["BASE_URI"]
             dataset_uri = URIRef(f"{BASE_URI}/id/{ds['identifier']}")
             publisher_uri = URIRef(f"{dataset_uri}/publisher")
             distribution_uri = URIRef(f"{dataset_uri}/distribution")
@@ -130,7 +130,7 @@ def migrate_to_fuseki():
 
             catalog_graph.add((catalog_uri, DCAT.dataset, dataset_uri))
 
-    BASE_URI = os.getenv("BASE_URI", "https://semantic-data-catalog.com")
+    BASE_URI = os.environ["BASE_URI"]
     upload_named_graph(catalog_graph, graph_uri=f"{BASE_URI}/catalog")
 
     print("Migration completed.")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     stdin_open: true
     environment:
       - REACT_APP_OIDC_ISSUER=https://solidcommunity.net
-      - REACT_APP_REDIRECT_URL=${FRONTEND_REDIRECT:-http://localhost:5000}
+      - REACT_APP_REDIRECT_URL=http://localhost:5000
       - REACT_APP_VERSION=0.5.0
     tty: true
     depends_on:


### PR DESCRIPTION
## Summary
- remove scattered .env files and rely on docker-compose
- update backend to read required settings only from the environment
- document new workflow and move frontend redirect into compose file

## Testing
- `pytest`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba935cb9d0832aa86af6b2042c5256