### PR TITLE
fix: align alembic revision id

### DIFF
--- a/backend/alembic/versions/7a055a194917_initial_migration.py
+++ b/backend/alembic/versions/7a055a194917_initial_migration.py
@@ -1,6 +1,6 @@
 """initial migration
 
-Revision ID: 11915fdc90a2
+Revision ID: 7a055a194917
 Revises: 
 Create Date: 2025-05-13 18:33:21.278363
 
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import mysql
 
 
 # revision identifiers, used by Alembic.
-revision: str = '11915fdc90a2'
+revision: str = '7a055a194917'
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/populate.py
+++ b/backend/populate.py
@@ -2,7 +2,7 @@ import os
 from os import getenv
 import uuid
 from sqlalchemy.orm import Session
-from database import SessionLocal
+from database import SessionLocal, engine, Base
 from crud import create_dataset, create_catalog, get_dataset_by_identifier, get_catalog
 from triplestore_migration import migrate_to_fuseki, reset_triplestore, ensure_fuseki_dataset_exists
 from schemas import DatasetCreate, CatalogCreate
@@ -11,6 +11,9 @@ from datetime import datetime, timedelta
 
 def reset_database(db: Session):
     from models import Dataset, Catalog
+
+    Base.metadata.create_all(bind=engine)
+
     db.query(Dataset).delete()
     db.query(Catalog).delete()
     db.commit()


### PR DESCRIPTION
## Summary
- align Alembic revision ID with expected value to prevent migration failures
- ensure populate script creates tables before clearing data to avoid missing table errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baac576c00832aaefa7a2d691cad9a