### PR TITLE
Use docker-compose environment variables only

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,0 @@
-BASE_URI=http://localhost/semantic-data-catalog/
-DATABASE_URL=mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog
-FRONTEND_REDIRECT=http://localhost/semantic-data-catalog/

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,0 @@
-BASE_URI=https://semantic-data-catalog.com
-DATABASE_URL=mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog
-FRONTEND_REDIRECT=https://semantic-data-catalog.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore environment variable files
+.env.local
+.env.production

--- a/README.md
+++ b/README.md
@@ -11,26 +11,24 @@ A FAIR-compliant **Semantic Data Catalog** designed for decentralized Solid-base
 ### Local Deployment
 
 ```bash
-docker-compose --env-file .env.local up -d --build
+docker-compose up -d --build
 ```
 
-This starts the full stack locally, including frontend, backend, Fuseki, and MariaDB. Make sure to create a `.env.local` file in the root with all required environment variables (see below).
+This starts the full stack locally, including frontend, backend, Fuseki, and MariaDB. Environment variables are configured directly in the `docker-compose.yaml`.
 
 The frontend will be available at [http://localhost:5000](http://localhost:5000).
 
 ### Production Deployment
+Adjust the environment variables in `docker-compose.yaml` for your target environment and then run:
 
 ```bash
-docker-compose --env-file .env.production up -d --build
+docker-compose up -d --build
 ```
-
-Use a dedicated `.env.production` file to provide production-specific environment variables.
 
 ---
 
 ## Environment Configuration
-
-You can customize the deployment by changing environment variables in your `.env.local` or `.env.production` file. Here's how key variables map to the `docker-compose.yaml`:
+You can customize the deployment by editing environment variables in the `docker-compose.yaml`. Here's how key variables map to the `docker-compose.yaml`:
 
 ### Database (`db` service)
 
@@ -69,7 +67,7 @@ environment:
 
 ### Frontend (`frontend` service)
 
-Set these in your `.env.local` to control Solid login and version display:
+Set these in the `environment` block of the `frontend` service in `docker-compose.yaml` to control Solid login and version display:
 
 ```env
 REACT_APP_OIDC_ISSUER=https://solidcommunity.net

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     stdin_open: true
     environment:
       - REACT_APP_OIDC_ISSUER=https://solidcommunity.net
-      - REACT_APP_REDIRECT_URL=${FRONTEND_REDIRECT:-http://localhost:5000}
+      - REACT_APP_REDIRECT_URL=http://localhost:5000
       - REACT_APP_VERSION=0.5.0
     tty: true
     depends_on:


### PR DESCRIPTION
## Summary
- remove .env.local and .env.production files
- document environment setup directly in docker-compose
- define redirect URL via docker-compose instead of external env files
- ignore local env files in version control

## Testing
- `pytest`
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bacbaded68832a88468723464ba7c9