### PR TITLE
Store Solid authentication data in sessionStorage

### DIFF
--- a/frontend/src/solidSession.js
+++ b/frontend/src/solidSession.js
@@ -1,11 +1,33 @@
 import { Session } from "@inrupt/solid-client-authn-browser";
 
+// Simple IStorage wrapper backed by the browser's sessionStorage so that
+// authentication data is kept only for the lifetime of the tab.
+const sessionStorageWrapper = {
+  get: async (key) =>
+    typeof window === "undefined"
+      ? undefined
+      : window.sessionStorage.getItem(key) ?? undefined,
+  set: async (key, value) => {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(key, value);
+    }
+  },
+  delete: async (key) => {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(key);
+    }
+  },
+};
+
 // Create a dedicated Solid session for this app with its own session ID so
 // that multiple applications running on the same domain don't overwrite each
 // other's authentication state in localStorage.
 export const session = new Session({
   clientName: "Semantic Data Catalog",
   sessionId: "semantic-data-catalog",
+  // Store session state in sessionStorage rather than localStorage
+  secureStorage: sessionStorageWrapper,
+  insecureStorage: sessionStorageWrapper,
 });
 
 // Restore a previous Solid session, if any, and handle redirects coming back


### PR DESCRIPTION
## Summary
- Add sessionStorage-backed IStorage wrapper for Solid sessions so credentials only persist for the browser session
- Confirm components use the shared session export

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bbc99263f0832a91a02d0f973c7689