### PR TITLE
feat: upload semantic model file from pod

### DIFF
--- a/frontend/src/components/DatasetAddModal.js
+++ b/frontend/src/components/DatasetAddModal.js
@@ -143,6 +143,16 @@ const DatasetAddModal = ({ onClose, fetchDatasets, fetchTotalPages }) => {
       setLoading(true);
 
       const formData = new FormData();
+
+      if (newDataset.access_url_semantic_model) {
+        const response = await session.fetch(newDataset.access_url_semantic_model);
+        const blob = await response.blob();
+        const filename =
+          newDataset.access_url_semantic_model.split('/').pop() || "model.ttl";
+        const file = new File([blob], filename, { type: "text/turtle" });
+        formData.append("semantic_model_file", file);
+      }
+
       Object.entries(newDataset).forEach(([key, value]) => formData.append(key, value));
       formData.append("webid", webId);
 


### PR DESCRIPTION
## Summary
- load selected semantic model from the user's Solid pod via the session
- send semantic model TTL as multipart file when creating datasets

## Testing
- `pytest`
- `npm test --prefix frontend -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68be744e41d4832a87195b62ac7ce6d6