### PR TITLE
Silence ACL errors for restricted datasets

### DIFF
--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -83,7 +83,9 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId }) => {
           const access = getAgentAccess(file, sessionWebId);
           return access && Object.values(access).some(Boolean);
         } catch (err) {
-          console.error("Failed to check ACL for", url, err);
+          if (err.statusCode !== 403) {
+            console.error("Failed to check ACL for", url, err);
+          }
           return false;
         }
       };


### PR DESCRIPTION
## Summary
- Avoid logging 403 errors when checking ACL for dataset resources
- Keep dataset and model access flags accurate without console noise

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be98988d0c832ab6ba251b2b5f1c20