### PR TITLE
Check dataset access with ranged GET request

### DIFF
--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -75,10 +75,20 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId }) => {
       const hasAccess = async (url) => {
         if (!url) return false;
         try {
-          const res = await session.fetch(url, { method: "HEAD" });
+          const res = await session.fetch(url, {
+            method: "GET",
+            headers: { Range: "bytes=0-0" },
+          });
+          if (res.body && res.body.cancel) {
+            try {
+              await res.body.cancel();
+            } catch (e) {
+              // ignore cancellation errors
+            }
+          }
           return res.ok;
         } catch (err) {
-          console.warn("Failed to check access for", url, err);
+          console.debug("Access check failed for", url, err);
           return false;
         }
       };


### PR DESCRIPTION
## Summary
- Avoid `HEAD` requests when verifying dataset access
- Use ranged `GET` and cancel the body to minimize 403 console errors

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be9e93cff8832aade462acc1072f1b