### PR TITLE
Fix dataset access request by passing WebID

### DIFF
--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -226,6 +226,7 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId }) => {
       {showRequestModal && (
         <RequestDatasetModal
           dataset={dataset}
+          sessionWebId={sessionWebId}
           onClose={() => setShowRequestModal(false)}
         />
       )}


### PR DESCRIPTION
## Summary
- Pass session WebID to RequestDatasetModal so backend receives required field

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bea0c22ac8832a9457bef92df773b5