### PR TITLE
Align dataset edit modal with updated add dataset

### DIFF
--- a/frontend/src/components/DatasetEditModal.js
+++ b/frontend/src/components/DatasetEditModal.js
@@ -118,12 +118,15 @@ const DatasetEditModal = ({ dataset, onClose, fetchDatasets }) => {
       }
   
       Object.entries(editedDataset).forEach(([key, val]) => {
-        if (val !== null && val !== undefined && key !== "semantic_model_file") {
+        if (
+          val !== null &&
+          val !== undefined &&
+          key !== "semantic_model_file" &&
+          key !== "catalog_id"
+        ) {
           formData.append(key, val);
         }
       });
-  
-      formData.append("catalog_id", "1");
   
       await axios.put(`/api/datasets/${editedDataset.identifier}`, formData, {
         headers: { "Content-Type": "multipart/form-data" }
@@ -260,7 +263,18 @@ const DatasetEditModal = ({ dataset, onClose, fetchDatasets }) => {
             <div>
               <h6 className="text-muted">Files from Solid Pod</h6>
               {renderFileCards("Select Dataset File (CSV/JSON)", "access_url_dataset", datasetPodFiles, "fa-file-csv")}
-              {renderFileCards("Select Semantic Model File (TTL)", "access_url_semantic_model", modelPodFiles, "fa-project-diagram")}
+              <div className="d-flex justify-content-between align-items-center mb-2">
+                <label className="font-weight-bold mb-0">Select Semantic Model File (TTL)</label>
+                <a
+                  href="http://plasma.uni-wuppertal.de/modelings"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-outline-primary btn-sm"
+                >
+                  <i className="fa-solid fa-plus mr-1"></i> Create Semantic Model
+                </a>
+              </div>
+              {renderFileCards("", "access_url_semantic_model", modelPodFiles, "fa-project-diagram")}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Exclude catalog_id from dataset update payload and remove hardcoded value
- Add link to create semantic model and replicate file card layout in edit modal

## Testing
- `CI=true npm test -- --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb92bc110832a8277300e684e7ff8