### PR TITLE
Sort datasets by title alphabetically

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -31,7 +31,13 @@ def get_dataset(db: Session, dataset_id: int):
     return db.query(DatasetModel).filter(DatasetModel.identifier == dataset_id).first()
 
 def get_datasets(db: Session, skip: int = 0, limit: int = 10):
-    datasets = db.query(DatasetModel).offset(skip).limit(limit).all()
+    datasets = (
+        db.query(DatasetModel)
+        .order_by(DatasetModel.title.asc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
 
     for dataset in datasets:
         if dataset.semantic_model_file:


### PR DESCRIPTION
## Summary
- ensure backend returns datasets ordered by title A-Z

## Testing
- `pytest`
- `CI=true npm test` (fails: no tests found)

------
https://chatgpt.com/codex/tasks/task_e_68bebabad850832aada503c62acc4593