### PR TITLE
Use IONOS SMTP settings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,11 +30,11 @@ services:
       - DATABASE_URL=mysql+pymysql://semantic_data_catalog:mNXZqSq4oK53Q7@db:3306/semantic_data_catalog
       - RESET_DB=true
       - RUN_POPULATE=true
-      - SMTP_HOST=smtp.gmail.com
+      - SMTP_HOST=smtp.ionos.de
       - SMTP_PORT=587
-      - SMTP_USER=soliddataspace@gmail.com
-      - SMTP_PASS=xbrvpsBAymBv3y
-      - EMAIL_FROM=soliddataspace@gmail.com
+      - SMTP_USER=f.hoelken@gaba-network.de
+      - SMTP_PASS=abc.123
+      - EMAIL_FROM=f.hoelken@gaba-network.de
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- configure backend service to send email via IONOS instead of Gmail

## Testing
- `python - <<'PY'
import yaml,sys
with open('docker-compose.yaml') as f:
    yaml.safe_load(f)
print('YAML is valid')
PY`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bebd569f70832a991ff834cd5b79b8