### PR TITLE
Handle missing SMTP config for access requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ environment:
 - `RESET_DB`: Set to `true` during development to drop and recreate all tables on startup
 - `RUN_POPULATE`: Whether to auto-run the `populate.py` script (loads test data)
 
+#### Email Notifications
+
+To enable email notifications for dataset access requests, define the following variables for the backend service:
+
+```yaml
+environment:
+  - SMTP_HOST=smtp.example.org
+  - SMTP_PORT=587
+  - SMTP_USER=optional_username
+  - SMTP_PASS=optional_password
+  - EMAIL_FROM=notifications@example.org
+```
+
+If these values are not provided, access requests are logged but no email is sent.
+
 ---
 
 ### Frontend (`frontend` service)

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ app = FastAPI()
 
 class AccessRequest(BaseModel):
     webid: str
+    message: Optional[str] = None
 
 
 def get_db():
@@ -238,12 +239,15 @@ def request_dataset_access(identifier: str, payload: AccessRequest, db: Session 
     )
 
     if not smtp_host or not smtp_port or not email_from:
-        raise HTTPException(status_code=500, detail="SMTP configuration missing")
+        print("SMTP configuration missing; skipping email dispatch")
+        return {"detail": "Request logged; email not sent"}
 
     subject = f"Zugriffsanfrage für {dataset.title}"
     body = (
         f"Der Nutzer mit WebID {payload.webid} bittet um Zugriff auf {dataset.title} ({identifier})."
     )
+    if payload.message:
+        body += f"\n\nNachricht des Nutzers:\n{payload.message}"
     message = f"Subject: {subject}\nFrom: {email_from}\nTo: {dataset.contact_point}\n\n{body}"
 
     try:


### PR DESCRIPTION
## Summary
- Allow dataset access requests without SMTP configuration, logging instead of failing
- Support optional message in access request emails
- Document SMTP environment variables for email notifications

## Testing
- `python -m py_compile backend/main.py`
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bec000f068832a807177b136411a3b