### PR TITLE
Enhance dataset access request email

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,8 @@ const App = () => {
   const [selectedDataset, setSelectedDataset] = useState(null);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [webId, setWebId] = useState(null);
+  const [userName, setUserName] = useState('');
+  const [userEmail, setUserEmail] = useState('');
   const [showOntologyDropdown, setShowOntologyDropdown] = useState(false);
   const toggleOntologyDropdown = () => setShowOntologyDropdown(prev => !prev);
 
@@ -115,6 +117,10 @@ const App = () => {
       <HeaderBar
         onLoginStatusChange={setIsLoggedIn}
         onWebIdChange={setWebId}
+        onUserInfoChange={({ name, email }) => {
+          setUserName(name);
+          setUserEmail(email);
+        }}
         activeTab={activeTab}
         setActiveTab={setActiveTab}
       />
@@ -220,6 +226,8 @@ const App = () => {
           dataset={selectedDataset}
           onClose={handleCloseModal}
           sessionWebId={webId}
+          userName={userName}
+          userEmail={userEmail}
         />
       )}
       {showDeleteModal && (

--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -31,7 +31,7 @@ const handleFileDownload = async (url, fileName) => {
   }
 };
 
-const DatasetDetailModal = ({ dataset, onClose, sessionWebId }) => {
+const DatasetDetailModal = ({ dataset, onClose, sessionWebId, userName, userEmail }) => {
   const [triples, setTriples] = useState([]);
   const [canAccessDataset, setCanAccessDataset] = useState(false);
   const [canAccessModel, setCanAccessModel] = useState(false);
@@ -227,6 +227,8 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId }) => {
         <RequestDatasetModal
           dataset={dataset}
           sessionWebId={sessionWebId}
+          userName={userName}
+          userEmail={userEmail}
           onClose={() => setShowRequestModal(false)}
         />
       )}

--- a/frontend/src/components/HeaderBar.js
+++ b/frontend/src/components/HeaderBar.js
@@ -9,7 +9,7 @@ import {
 import { FOAF, VCARD } from "@inrupt/vocab-common-rdf";
 import LoginIssuerModal from './LoginIssuerModal';
 
-const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab }) => {
+const HeaderBar = ({ onLoginStatusChange, onWebIdChange, onUserInfoChange, activeTab, setActiveTab }) => {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [userInfo, setUserInfo] = useState({
     loggedIn: false,
@@ -83,6 +83,7 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
 
       if (onLoginStatusChange) onLoginStatusChange(true);
       if (onWebIdChange) onWebIdChange(webId);
+      if (onUserInfoChange) onUserInfoChange({ name, email });
 
     } catch (err) {
       console.error("Error loading pod profile info:", err);
@@ -114,6 +115,7 @@ const HeaderBar = ({ onLoginStatusChange, onWebIdChange, activeTab, setActiveTab
       photo: ''
     });
     if (onLoginStatusChange) onLoginStatusChange(false);
+    if (onUserInfoChange) onUserInfoChange({ name: '', email: '' });
     session.logout({ logoutRedirectUrl: window.location.href });
     window.location.reload();
   };

--- a/frontend/src/components/RequestDatasetModal.js
+++ b/frontend/src/components/RequestDatasetModal.js
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-const RequestDatasetModal = ({ dataset, sessionWebId, onClose }) => {
+const RequestDatasetModal = ({ dataset, sessionWebId, userName, userEmail, onClose }) => {
   const [message, setMessage] = useState('');
 
   const handleRequest = async () => {
     try {
       await axios.post(`/api/datasets/${dataset.identifier}/request-access`, {
         webid: sessionWebId,
+        name: userName,
+        email: userEmail,
         ...(message ? { message } : {})
       });
       alert('Access request sent successfully.');


### PR DESCRIPTION
## Summary
- include requester name and email in access request payload
- format access request email with greeting, dataset details, and approval instructions
- propagate user info through frontend so it is sent with access request

## Testing
- `python -m py_compile backend/main.py`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bec629c94c832a8575b021ac8d55c6