### PR TITLE
Show modal confirmation after dataset access request

### DIFF
--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -3,6 +3,7 @@ import { Parser } from 'n3';
 import { session } from "../solidSession";
 import RDFGraph from "./RDFGraph";
 import RequestDatasetModal from "./RequestDatasetModal";
+import RequestSuccessModal from "./RequestSuccessModal";
 
 const formatDate = (dateString) => {
   if (!dateString) return "N/A";
@@ -36,6 +37,7 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId, userName, userEmai
   const [canAccessDataset, setCanAccessDataset] = useState(false);
   const [canAccessModel, setCanAccessModel] = useState(false);
   const [showRequestModal, setShowRequestModal] = useState(false);
+  const [showRequestSuccess, setShowRequestSuccess] = useState(false);
 
   useEffect(() => {
     if (!dataset?.semantic_model_file) return;
@@ -230,7 +232,11 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId, userName, userEmai
           userName={userName}
           userEmail={userEmail}
           onClose={() => setShowRequestModal(false)}
+          onSuccess={() => setShowRequestSuccess(true)}
         />
+      )}
+      {showRequestSuccess && (
+        <RequestSuccessModal onClose={() => setShowRequestSuccess(false)} />
       )}
     </>
   );

--- a/frontend/src/components/RequestDatasetModal.js
+++ b/frontend/src/components/RequestDatasetModal.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-const RequestDatasetModal = ({ dataset, sessionWebId, userName, userEmail, onClose }) => {
+const RequestDatasetModal = ({ dataset, sessionWebId, userName, userEmail, onClose, onSuccess }) => {
   const [message, setMessage] = useState('');
 
   const handleRequest = async () => {
@@ -12,8 +12,8 @@ const RequestDatasetModal = ({ dataset, sessionWebId, userName, userEmail, onClo
         email: userEmail,
         ...(message ? { message } : {})
       });
-      alert('Access request sent successfully.');
       onClose();
+      if (onSuccess) onSuccess();
     } catch (error) {
       console.error('Error requesting dataset access:', error);
     }

--- a/frontend/src/components/RequestSuccessModal.js
+++ b/frontend/src/components/RequestSuccessModal.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const RequestSuccessModal = ({ onClose }) => {
+  return (
+    <div className="modal fade show modal-show" tabIndex="-1" role="dialog">
+      <div className="modal-dialog modal-lg" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">
+              <i className="fa-solid fa-paper-plane mr-2"></i> Request Sent
+            </h5>
+            <button type="button" className="close" onClick={onClose} aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <div className="modal-body text-center">
+            <i className="fa-solid fa-circle-check fa-4x text-success mb-3"></i>
+            <p>Your access request email has been sent successfully.</p>
+          </div>
+
+          <div className="modal-footer justify-content-end">
+            <button type="button" className="btn btn-primary" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RequestSuccessModal;
+


### PR DESCRIPTION
## Summary
- Display custom `RequestSuccessModal` after dataset access request instead of browser alert
- Wire up success callback between DatasetDetailModal and RequestDatasetModal

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bec971a57c832aa5cd2b29e85d07e9