### PR TITLE
feat: enlarge semantic model on double click

### DIFF
--- a/frontend/src/components/DatasetDetailModal.js
+++ b/frontend/src/components/DatasetDetailModal.js
@@ -4,6 +4,7 @@ import { session } from "../solidSession";
 import RDFGraph from "./RDFGraph";
 import RequestDatasetModal from "./RequestDatasetModal";
 import RequestSuccessModal from "./RequestSuccessModal";
+import SemanticModelModal from "./SemanticModelModal";
 import { getFileWithAcl, getAgentAccess } from "@inrupt/solid-client";
 
 const formatDate = (dateString) => {
@@ -39,6 +40,7 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId, userName, userEmai
   const [canAccessModel, setCanAccessModel] = useState(false);
   const [showRequestModal, setShowRequestModal] = useState(false);
   const [showRequestSuccess, setShowRequestSuccess] = useState(false);
+  const [showSemanticModal, setShowSemanticModal] = useState(false);
 
   useEffect(() => {
     if (!dataset?.semantic_model_file) return;
@@ -213,8 +215,15 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId, userName, userEmai
                 </ul>
               </div>
 
-              <div className="dataset-detail-right d-flex align-items-center justify-content-center ml-3">
-                {triples.length > 0 ? <RDFGraph triples={triples} /> : <p className="text-muted">No RDF triples found.</p>}
+              <div
+                className="dataset-detail-right d-flex align-items-center justify-content-center ml-3"
+                title="Double-click to enlarge"
+              >
+                {triples.length > 0 ? (
+                  <RDFGraph triples={triples} onDoubleClick={() => setShowSemanticModal(true)} />
+                ) : (
+                  <p className="text-muted">No RDF triples found.</p>
+                )}
               </div>
             </div>
           </div>
@@ -232,6 +241,9 @@ const DatasetDetailModal = ({ dataset, onClose, sessionWebId, userName, userEmai
       )}
       {showRequestSuccess && (
         <RequestSuccessModal onClose={() => setShowRequestSuccess(false)} />
+      )}
+      {showSemanticModal && (
+        <SemanticModelModal triples={triples} onClose={() => setShowSemanticModal(false)} />
       )}
     </>
   );

--- a/frontend/src/components/RDFGraph.js
+++ b/frontend/src/components/RDFGraph.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { Network } from "vis-network";
 import "vis-network/styles/vis-network.css";
 
-const RDFGraph = ({ triples }) => {
+const RDFGraph = ({ triples, onDoubleClick }) => {
   const networkRef = useRef(null);
   const resizeObserver = useRef(null);
 
@@ -98,7 +98,7 @@ const RDFGraph = ({ triples }) => {
     };
   }, [triples]);
 
-  return <div ref={networkRef} className="rdf-graph-container" />;
+  return <div ref={networkRef} className="rdf-graph-container" onDoubleClick={onDoubleClick} />;
 };
 
 export default RDFGraph;

--- a/frontend/src/components/SemanticModelModal.js
+++ b/frontend/src/components/SemanticModelModal.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import RDFGraph from './RDFGraph';
+
+const SemanticModelModal = ({ triples, onClose }) => (
+  <div className="modal fade show modal-show" tabIndex="-1" role="dialog">
+    <div className="modal-dialog modal-xl" role="document">
+      <div className="modal-content">
+        <div className="modal-header">
+          <h5 className="modal-title">
+            <i className="fa-solid fa-project-diagram mr-2"></i> Semantic Model
+          </h5>
+          <button type="button" className="close" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div className="modal-body">
+          {triples.length > 0 ? (
+            <RDFGraph triples={triples} />
+          ) : (
+            <p className="text-muted">No RDF triples found.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default SemanticModelModal;


### PR DESCRIPTION
## Summary
- open semantic model in its own modal when double-clicked in dataset details
- allow RDFGraph to forward double-click events
- add SemanticModelModal component for enlarged view

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfe6353204832a8043fc3b843817ab