### PR TITLE
Improve database resilience and validate pagination

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -31,6 +31,8 @@ def get_dataset(db: Session, dataset_id: int):
     return db.query(DatasetModel).filter(DatasetModel.identifier == dataset_id).first()
 
 def get_datasets(db: Session, skip: int = 0, limit: int = 10):
+    skip = max(skip, 0)
+
     datasets = (
         db.query(DatasetModel)
         .order_by(DatasetModel.title.asc())
@@ -104,6 +106,8 @@ def get_catalog(db: Session, catalog_id: int):
     return db.query(Catalog).filter(Catalog.id == catalog_id).first()
 
 def get_catalogs(db: Session, skip: int = 0, limit: int = 10):
+    skip = max(skip, 0)
+
     return db.query(Catalog).offset(skip).limit(limit).all()
 
 def delete_catalog(db: Session, catalog_id: int):

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,6 +5,12 @@ import os
 
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL")
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+POOL_RECYCLE_SECONDS = int(os.getenv("DATABASE_POOL_RECYCLE", "3600"))
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    pool_pre_ping=True,
+    pool_recycle=POOL_RECYCLE_SECONDS,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -46,10 +46,11 @@ const App = () => {
 
   const fetchDatasets = async (page = currentPage) => {
     try {
-      const response = await axios.get(`/api/datasets?skip=${(page - 1) * pageSize}&limit=${pageSize}`);
+      const safePage = Math.max(1, page);
+      const response = await axios.get(`/api/datasets?skip=${(safePage - 1) * pageSize}&limit=${pageSize}`);
       const total = await fetchTotalPages();
 
-      const newCurrentPage = Math.min(page, total);
+      const newCurrentPage = Math.min(safePage, total);
       setCurrentPage(newCurrentPage);
       setTotalPages(total);
 


### PR DESCRIPTION
## Summary
- enable SQLAlchemy connection pre-ping and configurable pool recycle to recover cleanly from dropped MySQL connections
- guard dataset and catalog queries against negative pagination offsets on the backend and frontend

## Testing
- npm test -- --watchAll=false --passWithNoTests
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d2260f499c832aadd54752c37269db