### PR TITLE
Ensure dataset pagination bounds are safe

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,26 +36,26 @@ const App = () => {
       const response = await axios.get('/api/datasets/count');
       const totalDatasets = response.data.count;
       const pages = Math.ceil(totalDatasets / pageSize);
-      setTotalPages(pages);
+      const safePages = Math.max(pages, 1);
+      setTotalPages(safePages);
       return pages;
     } catch (error) {
       console.error("Error fetching dataset count:", error);
+      setTotalPages(1);
       return 1;
     }
   };
 
   const fetchDatasets = async (page = currentPage) => {
     try {
-      const safePage = Math.max(1, page);
-      const response = await axios.get(`/api/datasets?skip=${(safePage - 1) * pageSize}&limit=${pageSize}`);
       const total = await fetchTotalPages();
+      const safeTotal = Math.max(total, 1);
+      const safePage = Math.max(1, Math.min(page, safeTotal));
+      const response = await axios.get(`/api/datasets?skip=${(safePage - 1) * pageSize}&limit=${pageSize}`);
 
-      const newCurrentPage = Math.min(safePage, total);
-      setCurrentPage(newCurrentPage);
-      setTotalPages(total);
-
-      const finalResponse = await axios.get(`/api/datasets?skip=${(newCurrentPage - 1) * pageSize}&limit=${pageSize}`);
-      setDatasets(finalResponse.data);
+      setCurrentPage(safePage);
+      setTotalPages(safeTotal);
+      setDatasets(response.data);
     } catch (error) {
       console.error("Error fetching datasets:", error);
     }


### PR DESCRIPTION
## Summary
- clamp dataset pagination totals to a minimum of one
- bound requested pages to the available range before fetching datasets

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d230f29db0832a9dcc43984fab2a60