### PR TITLE
Update semantic search button to use Fuseki path

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -140,7 +140,7 @@ const App = () => {
                 Add Dataset
               </button>
               <a
-                href="http://localhost:3030/"
+                href="/fuseki/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn btn-light mr-2"


### PR DESCRIPTION
## Summary
- update the Semantic Search button in the frontend to open the Fuseki UI via the /fuseki/ path rather than relying on port 3030

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d24ec1c270832a95fdd3befc84904f