### PR TITLE
Fix dataset pagination loading reliability

### DIFF
--- a/frontend/src/components/DatasetAddModal.js
+++ b/frontend/src/components/DatasetAddModal.js
@@ -160,7 +160,7 @@ const DatasetAddModal = ({ onClose, fetchDatasets, fetchTotalPages }) => {
         headers: { "Content-Type": "multipart/form-data" },
       });
 
-      const pages = await fetchTotalPages();
+      const { pages } = await fetchTotalPages();
       await fetchDatasets(pages);
       onClose();
     } catch (err) {


### PR DESCRIPTION
## Summary
- consolidate dataset pagination handling so count and page data stay in sync
- add automatic retry when datasets exist but the current page returns empty results
- update the dataset add modal to work with the new pagination helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b384e988832a8b1b5c46987cdfa2